### PR TITLE
feat: Replace NSubstitute with TUnit.Mocks in test suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
-* text eol=lf
 
 # (binary is a macro for -text -diff)
 *.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,13 @@ MigrationBackup/
 # Prevent nested .editorconfig files - only root .editorconfig should be used
 **/.editorconfig
 !/.editorconfig
+
+# MemPalace per-project files
+.mempalace/
+mempalace.yaml
+entities.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,8 +24,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="NetEvolve.Extensions.TUnit" Version="3.5.348" />
+    <!-- Kept for one narrow fallback usage in NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration;
+         see the comment in that project's TestBase.cs and .csproj. -->
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="TUnit" Version="1.62.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.62.0" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/tests/NetEvolve.Http.Correlation.Abstractions.Tests.Unit/NetEvolve.Http.Correlation.Abstractions.Tests.Unit.csproj
+++ b/tests/NetEvolve.Http.Correlation.Abstractions.Tests.Unit/NetEvolve.Http.Correlation.Abstractions.Tests.Unit.csproj
@@ -5,7 +5,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
@@ -5,8 +5,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
+    <!-- NSubstitute is kept for one narrow usage in TestBase.cs: mocking IInvocationFeatures so that its
+         generic Get<T>() call for the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature
+         recurses into an automatic substitute at runtime, which TUnit.Mocks' compile-time source generator
+         cannot do for a type this assembly has no visibility into. See the comment in TestBase.cs. -->
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetEvolve.Http.Correlation.Azure.Functions\NetEvolve.Http.Correlation.Azure.Functions.csproj" />

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NetEvolve.Http.Correlation.Abstractions;
 using NSubstitute;
+using TUnit.Mocks;
 
 /// <summary>
 /// Test infrastructure for <see cref="FunctionsCorrelationMiddleware"/> integration tests.
@@ -32,7 +33,7 @@ public abstract class TestBase
         var serviceProvider = services.BuildServiceProvider();
         await using (serviceProvider.ConfigureAwait(false))
         {
-            var context = Substitute.For<FunctionContext>();
+            var context = FunctionContext.Mock();
             _ = context.InvocationId.Returns("test-invocation-id");
 
             var scope = serviceProvider.CreateAsyncScope();
@@ -40,22 +41,17 @@ public abstract class TestBase
             {
                 _ = context.InstanceServices.Returns(scope.ServiceProvider);
 
+                // Always required: FunctionContextHttpRequestExtensions.GetHttpRequestDataAsync() dereferences
+                // context.Features directly (no null-check), so an unconfigured (null) Features property throws
+                // even when there is no HTTP request to set up.
+                var features = Substitute.For<IInvocationFeatures>();
+                _ = context.Features.Returns(features);
+
                 if (requestSetup is not null)
                 {
                     var requestData = new TestHttpRequestData(context);
                     requestSetup(requestData);
-
-                    var httpRequestDataFeature = Substitute.For<IHttpRequestDataFeature>();
-
-#pragma warning disable CA2012 // NSubstitute fluent setup: ValueTask is intercepted by the substitute proxy, not actually consumed here
-                    _ = httpRequestDataFeature
-                        .GetHttpRequestDataAsync(context)
-                        .Returns(new ValueTask<HttpRequestData?>(requestData));
-#pragma warning restore CA2012
-
-                    var features = Substitute.For<IInvocationFeatures>();
-                    _ = features.Get<IHttpRequestDataFeature>().Returns(httpRequestDataFeature);
-                    _ = context.Features.Returns(features);
+                    SetupHttpRequestFeature(context, features, requestData);
                 }
 
                 var middleware = new FunctionsCorrelationMiddleware(
@@ -77,5 +73,28 @@ public abstract class TestBase
                 }
             }
         }
+    }
+
+    // TUnit.Mocks generates a fixed set of Get<T>() overloads at compile time, so an unconfigured call for any
+    // other T - such as the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature, which the
+    // middleware requests indirectly via context.GetInvocationResult() - falls through to a plain null and
+    // throws. NSubstitute is kept for just the feature collection: its proxy runs in an assembly the Functions
+    // Worker grants InternalsVisibleTo, so it can transparently substitute internal types at runtime without
+    // this assembly ever naming them (see dailydevops/healthchecks#2051 for the same fallback pattern).
+    private static void SetupHttpRequestFeature(
+        Mock<FunctionContext> context,
+        IInvocationFeatures features,
+        TestHttpRequestData requestData
+    )
+    {
+        var httpRequestDataFeature = IHttpRequestDataFeature.Mock();
+
+#pragma warning disable CA2012 // TUnit.Mocks fluent setup: ValueTask is intercepted by the mock proxy, not awaited here
+        // context.Object: a single implicit conversion to Arg<FunctionContext> is allowed, but chaining
+        // Mock<FunctionContext> -> FunctionContext -> Arg<FunctionContext> is two, which C# won't apply implicitly.
+        _ = httpRequestDataFeature.GetHttpRequestDataAsync(context.Object).Returns(requestData);
+#pragma warning restore CA2012
+
+        _ = features.Get<IHttpRequestDataFeature>().Returns(httpRequestDataFeature);
     }
 }

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit/FunctionsWorkerApplicationBuilderExtensionsTests.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit/FunctionsWorkerApplicationBuilderExtensionsTests.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using NetEvolve.Http.Correlation;
-using NSubstitute;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
+using TUnit.Mocks;
 
 public class FunctionsWorkerApplicationBuilderExtensionsTests
 {
@@ -29,7 +29,7 @@ public class FunctionsWorkerApplicationBuilderExtensionsTests
     {
         // Arrange
         var services = new ServiceCollection();
-        var builder = Substitute.For<IFunctionsWorkerApplicationBuilder>();
+        var builder = IFunctionsWorkerApplicationBuilder.Mock();
         _ = builder.Services.Returns(services);
 
         // Act / Assert
@@ -42,7 +42,7 @@ public class FunctionsWorkerApplicationBuilderExtensionsTests
         // Arrange
         var services = new ServiceCollection();
         _ = services.AddHttpCorrelation().WithGuidGenerator();
-        var builder = Substitute.For<IFunctionsWorkerApplicationBuilder>();
+        var builder = IFunctionsWorkerApplicationBuilder.Mock();
         _ = builder.Services.Returns(services);
 
         // Act

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit.csproj
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit.csproj
@@ -5,8 +5,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetEvolve.Http.Correlation.Azure.Functions\NetEvolve.Http.Correlation.Azure.Functions.csproj" />


### PR DESCRIPTION
## Summary

- Replaces [NSubstitute](https://nsubstitute.github.io/) with [`TUnit.Mocks`](https://tunit.dev/) (source-generated, AOT-compatible mocking) across the three test projects that referenced it, consolidating onto the TUnit ecosystem already used as the test framework.
- `using NSubstitute;` → `using TUnit.Mocks;`, `Substitute.For<T>()` → `T.Mock()`; `.Returns()`/`.Throws()` fluent syntax is unchanged.
- Closes #723.

## Scoped exception

`NSubstitute` is kept for one narrow usage in `TestBase.cs` (Azure.Functions.Tests.Integration): mocking `IInvocationFeatures` so its generic `Get<T>()` call resolves the *internal* Azure Functions Worker type `IFunctionBindingsFeature`. NSubstitute's runtime proxy lives in an assembly the Worker SDK grants `InternalsVisibleTo`, so it can transparently substitute a type our own assembly can't even name — something TUnit.Mocks' compile-time source generator structurally cannot do. Filed upstream: [thomhurst/TUnit#6514](https://github.com/thomhurst/TUnit/issues/6514). A related limitation (no genuinely-pending async `.Returns()` for timeout/race tests) was also filed as [thomhurst/TUnit#6515](https://github.com/thomhurst/TUnit/issues/6515), though it didn't end up blocking anything in this repo.

This mirrors the same migration and fallback pattern used in `dailydevops/healthchecks` (issue #2049 / PR #2051).

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors (net8.0/net9.0/net10.0)
- [x] `dotnet test` — 152/152 passed across all three target frameworks