### PR TITLE
feat(ulid): add NetEvolve.Http.Correlation.Ulid.ByteAether provider for monotonic correlation IDs

### DIFF
--- a/src/NetEvolve.Http.Correlation.Ulid.ByteAether/README.md
+++ b/src/NetEvolve.Http.Correlation.Ulid.ByteAether/README.md
@@ -30,6 +30,7 @@ Configure services to use ULID-based correlation IDs in your `Program.cs`:
 
 ```csharp
 using NetEvolve.Http.Correlation;
+using NetEvolve.Http.Correlation.Ulid.ByteAether;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -74,7 +75,7 @@ Structure:
 - **Strict Temporal & Monotonic Ordering**: Unlike standard ULID implementations that produce randomly ordered IDs within the same millisecond, this package leverages `ByteAether.Ulid` to guarantee strictly ordered monotonic ULIDs even during high-throughput sub-millisecond bursts.
 - **Shorter Representation**: 26 characters vs 36 for standard GUIDs.
 - **Better Database Performance**: Monotonic time-first ordering minimizes B-Tree index page fragmentation during high-volume database writes.
-- **No Coordination Required**: Lock-free distributed generation without inter-node coordination or collisions.
+- **No Central Coordinator Required**: Thread-safe monotonic generation within a process; cross-node ordering is not guaranteed and collisions remain probabilistic.
 
 ## Related Packages
 

--- a/tests/NetEvolve.Http.Correlation.Ulid.ByteAether.Tests.Unit/ULIDCorrelationIdProviderTests.cs
+++ b/tests/NetEvolve.Http.Correlation.Ulid.ByteAether.Tests.Unit/ULIDCorrelationIdProviderTests.cs
@@ -49,7 +49,7 @@ public class ULIDCorrelationIdProviderTests
         // Assert
         foreach (var id in values.Zip(values.Skip(1), (a, b) => (a, b)))
         {
-            _ = await Assert.That(id.a).IsLessThan(id.b);
+            _ = await Assert.That(string.CompareOrdinal(id.a, id.b)).IsLessThan(0);
         }
     }
 }


### PR DESCRIPTION
Adds the `NetEvolve.Http.Correlation.Ulid.ByteAether` provider, which generates correlation IDs via `ByteAether.Ulid` to guarantee strictly monotonic ordering for IDs created within the same millisecond — unlike the existing `NetEvolve.Http.Correlation.Ulid` package, whose IDs are randomly ordered inside a millisecond.

This supersedes #730 by @Seramis, whose commits are preserved here with original authorship. That PR could not be updated: "Allow edits by maintainers" is disabled on the source fork, so the review fixes below could not be pushed to it, and its workflow runs were additionally gated behind manual approval.

## Changes

- New package `src/NetEvolve.Http.Correlation.Ulid.ByteAether` with an internal `UlidCorrelationIdProvider` and a `WithUlidGenerator()` builder extension mirroring the existing ULID package.
- `ByteAether.Ulid` 1.4.0 added to central package management.
- Unit tests covering provider registration, null-argument handling, uniqueness under `Parallel.For`, and sequential ordering across net8.0/9.0/10.0.
- Package README plus a new "Using ULID Provider" section in the root README documenting both providers as alternatives.

## Review feedback from #730

Three findings from the automated review were adopted:

- The Basic Setup sample omitted `using NetEvolve.Http.Correlation.Ulid.ByteAether;`, the namespace declaring `WithUlidGenerator()`, so it could not compile as shown.
- The "No Coordination Required" benefit claimed distributed generation "without inter-node coordination or collisions". ByteAether's monotonicity derives from lock-free CAS over per-generator state, which establishes neither a total order across nodes nor collision-freedom. Reworded and scoped to a single process.
- Ordering assertions used TUnit's generic `IsLessThan`, which resolves through culture-sensitive `string.CompareTo`. ULID sortability is defined ordinally, so the test now asserts on `string.CompareOrdinal`.

Three were declined, with reasoning recorded in the #730 threads: splitting the root README snippet (exclusivity is already stated per import), extending the builder-contract test (would diverge from the identical test in `NetEvolve.Http.Correlation.Ulid.Tests.Unit`), and adding a clock seam for a same-millisecond monotonicity test (widens production API to assert a guarantee owned by the dependency).

## Verification

- `dotnet build`: 0 errors, 0 warnings.
- 15/15 unit tests pass on net8.0, net9.0, and net10.0.

## Notes

- Rebased onto current `main`, so it includes #731 (TUnit 1.62.0) and #732 (TUnit.Mocks migration); #730 was based on a stale `main`.
- `dotnet format` reports a pre-existing `CHARSET` error on `tests/NetEvolve.Http.Correlation.HttpClient.Tests.Unit/HttpCorrelationIdHandlerTests.cs` (missing UTF-8 BOM). Present on `main` since #604 and unrelated to this change; needs a separate fix.
