### PR TITLE
fix(slnx): re-add ByteAether ULID projects to solution

### DIFF
--- a/Http.Correlation.slnx
+++ b/Http.Correlation.slnx
@@ -19,6 +19,7 @@
     <Project Path="src/NetEvolve.Http.Correlation.Azure.Functions/NetEvolve.Http.Correlation.Azure.Functions.csproj" Id="639963ff-323b-4f12-804e-c1b97a2f1cf2" />
     <Project Path="src/NetEvolve.Http.Correlation.HttpClient/NetEvolve.Http.Correlation.HttpClient.csproj" />
     <Project Path="src/NetEvolve.Http.Correlation.TestGenerator/NetEvolve.Http.Correlation.TestGenerator.csproj" />
+    <Project Path="src/NetEvolve.Http.Correlation.Ulid.ByteAether/NetEvolve.Http.Correlation.Ulid.ByteAether.csproj" />
     <Project Path="src/NetEvolve.Http.Correlation.Ulid/NetEvolve.Http.Correlation.Ulid.csproj" />
   </Folder>
   <Folder Name="/tests/">
@@ -29,6 +30,7 @@
     <Project Path="tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit/NetEvolve.Http.Correlation.Azure.Functions.Tests.Unit.csproj" />
     <Project Path="tests/NetEvolve.Http.Correlation.HttpClient.Tests.Unit/NetEvolve.Http.Correlation.HttpClient.Tests.Unit.csproj" />
     <Project Path="tests/NetEvolve.Http.Correlation.TestGenerator.Tests.Unit/NetEvolve.Http.Correlation.TestGenerator.Tests.Unit.csproj" />
+    <Project Path="tests/NetEvolve.Http.Correlation.Ulid.ByteAether.Tests.Unit/NetEvolve.Http.Correlation.Ulid.ByteAether.Tests.Unit.csproj" />
     <Project Path="tests/NetEvolve.Http.Correlation.Ulid.Tests.Unit/NetEvolve.Http.Correlation.Ulid.Tests.Unit.csproj" />
   </Folder>
 </Solution>


### PR DESCRIPTION
## Problem

`src/NetEvolve.Http.Correlation.Ulid.ByteAether` and `tests/NetEvolve.Http.Correlation.Ulid.ByteAether.Tests.Unit` are missing from `Http.Correlation.slnx` on `main`, even though both projects exist in the repository.

## Cause

Commit 088c4a9 added both entries. Commit 6a1da81 (merged as 320fa58 via #733) was a documentation and test-assertion change, but also removed the two entries again.

## Change

Re-adds the two `<Project>` entries. The resulting `Http.Correlation.slnx` is byte-identical to the state introduced by 088c4a9.