### PR TITLE
chore(tests): replace NSubstitute with a DispatchProxy-based workaround

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,11 +24,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="NetEvolve.Extensions.TUnit" Version="3.5.348" />
-    <!-- Kept for one narrow fallback usage in NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration;
-         see the comment in that project's TestBase.cs and .csproj. -->
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="TUnit" Version="1.62.0" />
-    <PackageVersion Include="TUnit.Mocks" Version="1.62.0" />
+    <PackageVersion Include="TUnit" Version="1.63.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.63.0" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
     <PackageVersion Include="ByteAether.Ulid" Version="1.4.0" />
   </ItemGroup>

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
@@ -5,11 +5,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <!-- NSubstitute is kept for one narrow usage in TestBase.cs: mocking IInvocationFeatures so that its
-         generic Get<T>() call for the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature
-         recurses into an automatic substitute at runtime, which TUnit.Mocks' compile-time source generator
-         cannot do for a type this assembly has no visibility into. See the comment in TestBase.cs. -->
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NullReturningProxy.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NullReturningProxy.cs
@@ -1,0 +1,12 @@
+namespace NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration;
+
+using System;
+using System.Reflection;
+
+public class NullReturningProxy : DispatchProxy
+{
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+        targetMethod?.ReturnType is { IsValueType: true } rt && rt != typeof(void)
+            ? Activator.CreateInstance(rt)
+            : null;
+}

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
@@ -7,7 +7,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NetEvolve.Http.Correlation.Abstractions;
-using NSubstitute;
 using TUnit.Mocks;
 
 /// <summary>
@@ -44,7 +43,7 @@ public abstract class TestBase
                 // Always required: FunctionContextHttpRequestExtensions.GetHttpRequestDataAsync() dereferences
                 // context.Features directly (no null-check), so an unconfigured (null) Features property throws
                 // even when there is no HTTP request to set up.
-                var features = Substitute.For<IInvocationFeatures>();
+                var features = new TestInvocationFeatures();
                 _ = context.Features.Returns(features);
 
                 if (requestSetup is not null)
@@ -75,15 +74,12 @@ public abstract class TestBase
         }
     }
 
-    // TUnit.Mocks generates a fixed set of Get<T>() overloads at compile time, so an unconfigured call for any
-    // other T - such as the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature, which the
-    // middleware requests indirectly via context.GetInvocationResult() - falls through to a plain null and
-    // throws. NSubstitute is kept for just the feature collection: its proxy runs in an assembly the Functions
-    // Worker grants InternalsVisibleTo, so it can transparently substitute internal types at runtime without
-    // this assembly ever naming them (see dailydevops/healthchecks#2051 for the same fallback pattern).
+    // See TestInvocationFeatures.cs: the middleware requests the internal Microsoft.Azure.Functions.Worker type
+    // IFunctionBindingsFeature indirectly via context.GetInvocationResult(). This assembly cannot name that type,
+    // so TestInvocationFeatures.Get<T>() falls back to a DispatchProxy stub for any unregistered interface T.
     private static void SetupHttpRequestFeature(
         Mock<FunctionContext> context,
-        IInvocationFeatures features,
+        TestInvocationFeatures features,
         TestHttpRequestData requestData
     )
     {
@@ -95,6 +91,9 @@ public abstract class TestBase
         _ = httpRequestDataFeature.GetHttpRequestDataAsync(context.Object).Returns(requestData);
 #pragma warning restore CA2012
 
-        _ = features.Get<IHttpRequestDataFeature>().Returns(httpRequestDataFeature);
+        // The explicit <IHttpRequestDataFeature> type argument is load-bearing: it keys the dictionary on the
+        // interface type. If inferred from httpRequestDataFeature's concrete mock type instead, Get<IHttpRequestDataFeature>()
+        // below would miss and silently fall back to a DispatchProxy stub (see risk in TestInvocationFeatures.cs).
+        features.Set<IHttpRequestDataFeature>(httpRequestDataFeature);
     }
 }

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestInvocationFeatures.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestInvocationFeatures.cs
@@ -1,0 +1,41 @@
+namespace NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Azure.Functions.Worker;
+
+// Dependency-free stand-in for IInvocationFeatures. The middleware reaches
+// context.GetInvocationResult(), which asks Features for the internal Functions Worker type
+// IFunctionBindingsFeature - a type this assembly has no visibility into and can never name.
+// Get<T>() sidesteps that: T is a type parameter at this call site, so DispatchProxy.Create<T, ...>()
+// can synthesize a stub for it purely from the runtime Type object the Worker SDK supplies via
+// reflection, without this file ever spelling out the interface name.
+internal sealed class TestInvocationFeatures : IInvocationFeatures
+{
+    private readonly Dictionary<Type, object> _features = [];
+
+    public void Set<T>(T instance) => _features[typeof(T)] = instance!;
+
+    public T? Get<T>()
+    {
+        if (_features.TryGetValue(typeof(T), out var existing))
+        {
+            return (T)existing;
+        }
+
+        if (typeof(T).IsInterface)
+        {
+            var stub = DispatchProxy.Create<T, NullReturningProxy>();
+            _features[typeof(T)] = stub!;
+            return stub;
+        }
+
+        return default;
+    }
+
+    public IEnumerator<KeyValuePair<Type, object>> GetEnumerator() => _features.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}


### PR DESCRIPTION
## Summary

- Removes the NSubstitute dependency from `NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration`.
- Bumps `TUnit` and `TUnit.Mocks` to 1.63.0.
- **This is a workaround, not a full migration to `TUnit.Mocks`.** `TUnit.Mocks` is a compile-time source generator, so it cannot configure a mock's generic method for a type argument this assembly can't name — in this case the internal Azure Functions Worker type `IFunctionBindingsFeature`, which the SDK requests internally via `FunctionContext.GetInvocationResult()`. See thomhurst/TUnit#6514 for the upstream discussion; confirmed against 1.63.0 that the gap still exists.
- The workaround: `TestInvocationFeatures`, a small hand-written `IInvocationFeatures`, falls back to `DispatchProxy.Create<T, NullReturningProxy>()` for any unregistered interface `T`. Since `DispatchProxy.Create` is invoked with `T` as a generic parameter resolved at the call site via reflection, it works even for types this assembly has no visibility into.

## Test plan

- [x] `dotnet test` — 167/167 passing, including `NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration` on net8.0/net9.0/net10.0

Refs #723, thomhurst/TUnit#6514