### PR TITLE
test(azure-functions): replace NSubstitute with TUnit.Mocks in integration tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,11 +24,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="NetEvolve.Extensions.TUnit" Version="3.5.348" />
-    <!-- Kept for one narrow fallback usage in NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration;
-         see the comment in that project's TestBase.cs and .csproj. -->
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="TUnit" Version="1.62.0" />
-    <PackageVersion Include="TUnit.Mocks" Version="1.62.0" />
+    <PackageVersion Include="TUnit" Version="1.63.0" />
+    <PackageVersion Include="TUnit.Mocks" Version="1.63.0" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
     <PackageVersion Include="ByteAether.Ulid" Version="1.4.0" />
   </ItemGroup>

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration.csproj
@@ -5,11 +5,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NetEvolve.Extensions.TUnit" />
-    <!-- NSubstitute is kept for one narrow usage in TestBase.cs: mocking IInvocationFeatures so that its
-         generic Get<T>() call for the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature
-         recurses into an automatic substitute at runtime, which TUnit.Mocks' compile-time source generator
-         cannot do for a type this assembly has no visibility into. See the comment in TestBase.cs. -->
-    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Mocks" />
   </ItemGroup>

--- a/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
+++ b/tests/NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration/TestBase.cs
@@ -7,7 +7,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NetEvolve.Http.Correlation.Abstractions;
-using NSubstitute;
 using TUnit.Mocks;
 
 /// <summary>
@@ -44,7 +43,12 @@ public abstract class TestBase
                 // Always required: FunctionContextHttpRequestExtensions.GetHttpRequestDataAsync() dereferences
                 // context.Features directly (no null-check), so an unconfigured (null) Features property throws
                 // even when there is no HTTP request to set up.
-                var features = Substitute.For<IInvocationFeatures>();
+                //
+                // Requires TUnit.Mocks >= 1.63.0: the middleware always calls context.GetInvocationResult(), which
+                // internally requests the *internal* Worker type IFunctionBindingsFeature via Get<T>(). Only from
+                // 1.63.0 on does the generated mock auto-stub a T this assembly cannot name; on 1.62.0 the call
+                // returns null and GetRequired<T>() throws "No feature is registered with the type ...".
+                var features = IInvocationFeatures.Mock();
                 _ = context.Features.Returns(features);
 
                 if (requestSetup is not null)
@@ -75,15 +79,11 @@ public abstract class TestBase
         }
     }
 
-    // TUnit.Mocks generates a fixed set of Get<T>() overloads at compile time, so an unconfigured call for any
-    // other T - such as the internal Microsoft.Azure.Functions.Worker type IFunctionBindingsFeature, which the
-    // middleware requests indirectly via context.GetInvocationResult() - falls through to a plain null and
-    // throws. NSubstitute is kept for just the feature collection: its proxy runs in an assembly the Functions
-    // Worker grants InternalsVisibleTo, so it can transparently substitute internal types at runtime without
-    // this assembly ever naming them (see dailydevops/healthchecks#2051 for the same fallback pattern).
+    // The feature collection must stay typed as Mock<IInvocationFeatures>, not IInvocationFeatures: on the
+    // interface type, Get<T>() is the real method returning T, so there is nothing to chain .Returns() onto.
     private static void SetupHttpRequestFeature(
         Mock<FunctionContext> context,
-        IInvocationFeatures features,
+        Mock<IInvocationFeatures> features,
         TestHttpRequestData requestData
     )
     {


### PR DESCRIPTION
## Summary

- Removes the last NSubstitute usage in the repository — the `IInvocationFeatures` mock in `NetEvolve.Http.Correlation.Azure.Functions.Tests.Integration` — and drops the package entirely.
- Bumps `TUnit` and `TUnit.Mocks` to 1.63.0. This bump is part of the fix, not an incidental dependency update.

## Why it works now

Two separate blockers, both resolved:

1. **Compile time (CS1061).** `SetupHttpRequestFeature` took the feature collection as `IInvocationFeatures`. On the interface type, `Get<T>()` is the real method returning `T`, so there is nothing to chain `.Returns()` onto. Typing the parameter as `Mock<IInvocationFeatures>` — matching the existing `Mock<FunctionContext>` parameter — routes the call through the generated mock. Suggested by @thomhurst in thomhurst/TUnit#6514.
2. **Runtime (version floor).** The middleware always calls `context.GetInvocationResult()`, which internally requests the `internal` Worker type `IFunctionBindingsFeature` via `Get<T>()` — a type this assembly cannot name. Verified locally: on 1.62.0 that call returns null and `GetRequired<T>()` throws `InvalidOperationException: No feature is registered with the type Microsoft.Azure.Functions.Worker.Context.Features.IFunctionBindingsFeature`. On 1.63.0 the generated mock auto-stubs it and the tests pass. Both conditions are required; either one alone fails.

Both facts are recorded as comments in `TestBase.cs` so a future version pin or downgrade does not silently resurrect the failure.

This supersedes the closed #738, which worked around the same problem with a hand-written `TestInvocationFeatures` plus a `DispatchProxy` fallback. Those two helper types are no longer needed.

## Test plan

- [x] `dotnet test` — 167/167 passing across net8.0/net9.0/net10.0
- [x] Verified the failure mode on 1.62.0 to confirm the version floor is real

Refs #723, thomhurst/TUnit#6514
